### PR TITLE
Fix mclapply error on windows rhondabacher/SCnorm#2

### DIFF
--- a/R/GetSlopes.R
+++ b/R/GetSlopes.R
@@ -21,11 +21,9 @@ GetSlopes <- function(Data, SeqDepth = 0, Tau = .5, NCores) {
 	Genes <- names(which(NumNonZeros >= 10)) ##filter for now	
 	LogData <- redobox(Data, 0) #log data
     
-    if (.Platform$OS.type == "windows") {
-        NCores = 1
-    }
-
-	
+	if (.Platform$OS.type == "windows") {
+		NCores = 1
+	}
 	AllReg <- unlist(mclapply(X = 1:length(Genes), FUN = quickreg, InputData = list(LogData, SeqDepth, Genes, Tau), mc.cores = NCores))
 	
 	return(AllReg)

--- a/R/GetSlopes.R
+++ b/R/GetSlopes.R
@@ -20,6 +20,10 @@ GetSlopes <- function(Data, SeqDepth = 0, Tau = .5, NCores) {
 
 	Genes <- names(which(NumNonZeros >= 10)) ##filter for now	
 	LogData <- redobox(Data, 0) #log data
+    
+    if (.Platform$OS.type == "windows") {
+        NCores = 1
+    }
 
 	
 	AllReg <- unlist(mclapply(X = 1:length(Genes), FUN = quickreg, InputData = list(LogData, SeqDepth, Genes, Tau), mc.cores = NCores))

--- a/R/SCnorm.R
+++ b/R/SCnorm.R
@@ -128,7 +128,7 @@ SCnorm <- function(Data, Conditions, OutputName, PLOT = T, PropToUse = .25, outl
   
   checkCountDepth(Data = Data, NormalizedData = NORMDATA,
                   Conditions = Conditions, OutputName = "SCnorm_NormalizedData_FinalK", PLOT = PLOT,
-                  FilterCellProportion = FilterCellProportion, FilterExpression = FilterExpression)
+                  FilterCellProportion = FilterCellProportion, FilterExpression = FilterExpression, NCores = NCores)
   
   
   


### PR DESCRIPTION
I introduced the platform-dependent choice of NCores for mclapply in windows, which is basically a fallback to one core.
Related to that, I properly passed on the NCores argument from SCnorm() to checkCountDepth().