### PR TITLE
link to vignette

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ library(devtools)
 devtools::install_github("rhondabacher/SCnorm")
 ```
 
-Vignette is located here: [SCnorm Vignette](https://github.com/rhondabacher/SCnorm/blob/master/vignettes/SCnorm.pdf)
+Vignette is located here: [SCnorm Vignette](https://github.com/rhondabacher/SCnorm/blob/master/vignettes/SCnorm.Rnw)
 
 
 ## Author


### PR DESCRIPTION
Link was broken. Should this now link to the Rnw file ? 
There used to be a nice SCnorm.pdf in previous versions but it has been removed.